### PR TITLE
Sync RTC for arduino board

### DIFF
--- a/source/PoolMaster/PoolMaster.ino
+++ b/source/PoolMaster/PoolMaster.ino
@@ -428,10 +428,11 @@ void setup()
       }
       else
       {  
-        DateTime now = rtc.now();
-        setTime(now.hour(),(uint8_t)now.minute(),(uint8_t)now.second(),(uint8_t)now.day(),(uint8_t)now.month(),(uint16_t)now.year());     
+        setSyncProvider(&syncTimeRTC);
+        //setSyncInterval(30); // in seconds, default 300
       }      
     #endif
+
     
     //Define pins directions
     pinMode(FILTRATION_PUMP, OUTPUT);
@@ -527,6 +528,17 @@ void setup()
     //display remaining RAM space. For debug
     Serial<<F("[memCheck]: ")<<freeRam()<<F("b")<<_endl;
 }
+
+// provide function to sync time with RTC time
+time_t syncTimeRTC(){
+  DateTime now = rtc.now();
+
+  //convert Datetime to time_t
+  time_t tt = now.unixtime();
+
+  return tt;
+}
+
 
 //Connect to MQTT broker and subscribe to the PoolTopicAPI topic in order to receive future commands
 //then publish the "online" message on the "status" topic. If Ethernet connection is ever lost


### PR DESCRIPTION
I think that lib of controllino use already this. With Lib of classic meg2560 we must use setSyncProvider to keep synchronization with RTC.
In the old version of the source code, you read only on setup the RTC, and with the time we have a wrong time on arduino.
Now arduino time is sync every 30 seconds, and use another method of TimeLib.h ( setSynvProvider).

It's OK for me on my test during last weekend.