### PR TITLE
Incorrect error condition in ProcessCommand 

### DIFF
--- a/source/PoolMaster/PoolMaster.ino
+++ b/source/PoolMaster/PoolMaster.ino
@@ -1089,9 +1089,9 @@ void ProcessCommand(String JSONCommand)
   DeserializationError error = deserializeJson(command, JSONCommand);
 
   // Test if parsing succeeds.
-  if (!error)
+  if (error)
   {
-    Serial << F("Json parseObject() failed");
+    Serial << F("Json parseObject() failed: ") << error.f_str() << endl;
     return;
   }
   else


### PR DESCRIPTION
The error condition in ProcessCommand is inverted so correct MQTT API payloads are not processed.